### PR TITLE
Initial Viewer Access UI – Module 2B.2I

### DIFF
--- a/flutter_application_1/lib/pages/viewer_access_page.dart
+++ b/flutter_application_1/lib/pages/viewer_access_page.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+// Fake "Certificate Viewer" screen
+class CertificateViewScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Certificate Viewer')),
+      body: Center(
+        child: Text(
+          '🎓 Here is your certificate!',
+          style: TextStyle(fontSize: 22),
+        ),
+      ),
+    );
+  }
+}
+
+// Viewer Access Screen UI
+class ViewerAccessPage extends StatefulWidget {
+  @override
+  _ViewerAccessPageState createState() => _ViewerAccessPageState();
+}
+
+class _ViewerAccessPageState extends State<ViewerAccessPage> {
+  final TextEditingController tokenController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Access Certificate')),
+
+      body: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          children: [
+            // Input field for token/link
+            TextField(
+              controller: tokenController,
+              decoration: InputDecoration(
+                labelText: 'Enter token or link',
+                border: OutlineInputBorder(),
+              ),
+            ),
+
+            SizedBox(height: 20),
+
+            // Access button
+            ElevatedButton(
+              onPressed: () {
+                // Dummy logic: only allow "123456" as correct token
+                if (tokenController.text == '123456') {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => CertificateViewScreen()),
+                  );
+                } else {
+                  // Show error message if wrong
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('❌ Access Denied')),
+                  );
+                }
+              },
+              child: Text('Access Certificate'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
 Module: 2B.2 – Viewer Access Screen (UI Only)
This pull request adds the initial UI layout for the Viewer Access screen under Module 2B (Secure Sharing & Viewer Access). This part does not include Firebase or backend yet — it's purely for front-end demonstration and grading purposes.

✅ What I Implemented:
Viewer Access Page

Input field for entering a secure token or link.

“Access Certificate” button.

Basic Navigation Logic

If the input is 123456, the user is navigated to a dummy certificate viewer page.

If the input is incorrect, a red snackbar with the message “❌ Access Denied” appears.

Certificate Viewer Page

Displays a placeholder message: 🎓 Here is your certificate!





